### PR TITLE
Pharlap not Installing Driver - missing quotes

### DIFF
--- a/upstream/data/js/pharlap.js
+++ b/upstream/data/js/pharlap.js
@@ -100,7 +100,7 @@ app.controller('PharlapCtrl', function($scope, $modal) {
 
     var modalInstance = $modal.open({
       backdrop: 'static',
-      controller: PharlapProgressModalCtrl,
+      controller: 'PharlapProgressModalCtrl',
       size: 'lg',
       templateUrl: 'dnfProgressModal.html',
       windowClass: 'no-animation',


### PR DESCRIPTION
fixed: missing quotes in controller specification for install progress modal

This is at least part of the problem being seen in #18 


