### PR TITLE
Fix query to DNF for basearch via API

### DIFF
--- a/upstream/Pharlap/detect.py
+++ b/upstream/Pharlap/detect.py
@@ -23,7 +23,7 @@ from Pharlap.dnfcache import DNFCache
 from Pharlap.hwdata import PCI, USB
 
 db = dnf.Base()
-system_architecture = dnf.arch.basearch( hawkey.detect_arch() )
+system_architecture = dnf.rpm.basearch( hawkey.detect_arch() )
 
 device_pci = PCI()
 device_usb = USB()


### PR DESCRIPTION
This broke sometime between DNF 1.1.5 and 1.1.7 as it was an undocumented API. This PR switches it to the documented one, as seen in https://github.com/rpm-software-management/dnf/commit/e9c86c8a351176b13b3d0c60e4965aab85355323
